### PR TITLE
Add writing and streaming capabilities

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -15,6 +15,12 @@ pub enum IldaError {
   /// Problems were encountered while reading the ILDA data.
   InvalidData,
 
+  /// Too many points in a frame
+  TooManyPoints(usize),
+
+  /// Too many frames in an animation
+  TooManyFrames(usize),
+
   /// Problems were encountered while reading the ILDA data, specifically with
   /// an invalid ILDA header section.
   InvalidHeader,
@@ -40,6 +46,8 @@ impl Error for IldaError {
       IldaError::InvalidHeader => "InvalidHeader",
       IldaError::IoError { .. } => "IoError",
       IldaError::NoData => "NoData",
+      IldaError::TooManyPoints(_) => "TooManyPoints",
+      IldaError::TooManyFrames(_) => "TooManyFrames",
       IldaError::Unsupported => "Unsupported",
     }
   }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ pub mod animation;
 pub mod data;
 pub mod limit;
 pub mod parser;
+pub mod writer;
 
 mod color;
 mod error;

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,0 +1,98 @@
+//! Low level writing of ILDA frames.
+
+use data::IldaEntry;
+use data::ILDA_HEADER;
+use error::IldaError;
+use std::fs::File;
+use std::io::{BufWriter, Write};
+
+/// A struct that can be used to write IldaEntries to an underlying Write object
+pub struct IldaWriter<W: Write> where W: Write {
+  inner: W,
+}
+
+impl IldaWriter<BufWriter<File>> {
+  /// Crate an IldaWriter that writes to a file. (Buffered)
+  pub fn create(filename: &str) -> Result<IldaWriter<BufWriter<File>>, IldaError> {
+    let inner = BufWriter::new(File::create(filename)?);
+    Ok(IldaWriter::new(inner))
+  }
+}
+
+fn u16_be(value: u16) -> [u8; 2] {
+    [(value >> 8) as u8, (value & 0xFF) as u8]
+}
+
+fn str_8c(value: Option<String>) -> [u8; 8] {
+  let value = value.as_ref().map_or("", String::as_ref);
+  let mut arr = [0; 8];
+  let bytes = value.as_bytes();
+
+  for i in 0..bytes.len().min(8) {
+    arr[i] = bytes[i]
+  }
+
+  arr
+}
+
+impl<W: Write> IldaWriter<W> where W: Write {
+  /// Create a new IldaWriter. If writing to a file use `create` instead.
+  /// Using a buffered writer is highly recommended.
+  pub fn new(inner: W) -> IldaWriter<W> {
+    IldaWriter { inner }
+  }
+
+  /// Write an IldaEntry to the undelying writer.
+  pub fn write(&mut self, entry: IldaEntry) -> Result<(), IldaError> {
+    match entry {
+      IldaEntry::HeaderEntry(header) => {
+        self.inner.write(&ILDA_HEADER)?;
+        self.inner.write(&[0, 0, 0, header.format_code])?;
+        self.inner.write(&str_8c(header.name))?;
+        self.inner.write(&str_8c(header.company_name))?;
+        self.inner.write(&u16_be(header.record_count))?;
+        self.inner.write(&u16_be(header.number))?;
+        self.inner.write(&u16_be(header.total_frames))?;
+        self.inner.write(&[header.projector_number])?;
+        self.inner.write(&[0])?;
+      }
+      IldaEntry::TcPoint3dEntry(point) => {
+        self.inner.write(&u16_be(point.x as u16))?;
+        self.inner.write(&u16_be(point.y as u16))?;
+        self.inner.write(&u16_be(point.z as u16))?;
+        self.inner.write(&[point.status_code])?;
+        self.inner.write(&[point.b])?;
+        self.inner.write(&[point.g])?;
+        self.inner.write(&[point.r])?;
+      }
+      IldaEntry::TcPoint2dEntry(point) => {
+        self.inner.write(&u16_be(point.x as u16))?;
+        self.inner.write(&u16_be(point.y as u16))?;
+        self.inner.write(&[point.status_code])?;
+        self.inner.write(&[point.b])?;
+        self.inner.write(&[point.g])?;
+        self.inner.write(&[point.r])?;
+      }
+      IldaEntry::ColorPaletteEntry(palette) => {
+        self.inner.write(&[palette.r])?;
+        self.inner.write(&[palette.g])?;
+        self.inner.write(&[palette.b])?;
+      }
+      IldaEntry::IdxPoint3dEntry(point) => {
+        self.inner.write(&u16_be(point.x as u16))?;
+        self.inner.write(&u16_be(point.y as u16))?;
+        self.inner.write(&u16_be(point.z as u16))?;
+        self.inner.write(&[point.status_code])?;
+        self.inner.write(&[point.color_index])?;
+      }
+      IldaEntry::IdxPoint2dEntry(point) => {
+        self.inner.write(&u16_be(point.x as u16))?;
+        self.inner.write(&u16_be(point.y as u16))?;
+        self.inner.write(&[point.status_code])?;
+        self.inner.write(&[point.color_index])?;
+      }
+    };
+
+    Ok(())
+  }
+}


### PR DESCRIPTION
Some enhancements that I needed for my project that I would like to share. I should have split this into 2 PRs but one thing lead to another while developing.

1. Writing  

Create ILDA files from low level frames or animations. This should be pretty much self explanatory.

As for the interface, an object that has the `Write` trait is needed. The implementation also takes care about writing the last finishing header automatically or pragmatically. I am using a method that I mimicked from the https://github.com/ruuda/hound crate.

2. Streaming

As discussed in an issue earlier, I needed streaming capability for my project. I am basically creating never ending ILDA files on the fly that I would like to read/write.

For the interface I provide an Iterator over ILDA frames from objects that have `Read` implemented. This seemed most logical given the widespread use of `Read`/`Write` and `Iterator` in general.

You can choose from 2 iterators, one that yields `Result<IldaEntry, IldaError>` and an easier to use version that only yields `IldaEntry` but may panic.

3. Some refactoring

To achieve the above, I did some refactoring, mainly in the way how to handle and yield read new frames (both in parser and animation). There are some small interface changes, so I guess it would be best to raise the library version up to 0.3.
